### PR TITLE
Fixed critical bug

### DIFF
--- a/assets/scripts/templates/all-nodes.handlebars
+++ b/assets/scripts/templates/all-nodes.handlebars
@@ -16,8 +16,8 @@
         <td><a href="#" data-type="{{this.type}}" data-location="{{this.location}}">{{this.name}}</a></td>
         <td>{{this.updated_at}}</td>
         <td>{{this.tags}}</td>
-        <td><button type="button" class="btn edit-tags" data-toggle="modal" data-target="#edit-tags-modal" data-id="{{this._id}}" ><span class="glyphicon glyphicon-tags"></span></button></td>
-        <td><button type="button" class="btn btn-trash delete-node" data-toggle="modal" data-target="#delete-file-modal" data-id="{{this._id}}" ><span class="glyphicon glyphicon-trash"></span></button></td>
+        <td><button type="button" class="btn edit-tags" data-toggle="modal" data-target="#edit-tags-modal" data-id="{{this._id}}" ><span class="glyphicon glyphicon-tags" data-id="{{this._id}}"></span></button></td>
+        <td><button type="button" class="btn btn-trash delete-node" data-toggle="modal" data-target="#delete-file-modal" data-id="{{this._id}}" ><span class="glyphicon glyphicon-trash" data-id="{{this._id}}"></span></button></td>
       </tr>
     {{/nodes}}
   </tbody>


### PR DESCRIPTION
Span was added to delete and modify tags buttons; span did not have data-id;
this meant when we tried to delete something, we were passing the server
undefined rather than an id. Added data-id to the spans.
